### PR TITLE
Updated Functional Notes and toast to pass the entire updated note ob…

### DIFF
--- a/client/src/components/FunctionalToast.js
+++ b/client/src/components/FunctionalToast.js
@@ -9,9 +9,9 @@ function FunctionalToast(props) {
   const updateNote = () => {
 
     let record = {
-      _id: props.noteId,
-      title: props.noteTitle,
-      note: props.noteMessage, // New modified note is not getting passed to this field
+      _id: props.noteObjecttoBeUpdated._id,
+      title: props.noteObjecttoBeUpdated.title,
+      note: props.noteObjecttoBeUpdated.note, // New modified note is not getting passed to this field
     }
 
     /*  

--- a/client/src/pages/FunctionalNotes.js
+++ b/client/src/pages/FunctionalNotes.js
@@ -82,7 +82,7 @@ function FunctionalNotes() {
     function getThisUpdatedNote(data) {
         const thisUpdatedNote = allNotes.find(element => element._id === data._id);
         console.log("THIS UPDATED NOTE", thisUpdatedNote);
-        return thisUpdatedNote.note;
+        return thisUpdatedNote;
     };
 
     function displayFunction() {
@@ -178,15 +178,13 @@ function FunctionalNotes() {
                                                                 n[index].note = event.target.value;
                                                                 console.log("The current object of the n'th object in allNotes with a modified note: \n", n[index]);
                                                                 setAllNotes(n);
-                                                                setNoteIndex(index);
+                                                                // setNoteIndex(index);
                                                             }
                                                         }
                                                     >
 
                                                         <Toasts
-                                                            noteId={data._id}
-                                                            noteTitle={data.title}
-                                                            noteMessage={getThisUpdatedNote(data)} // <--- This is not passing through the new modified note, it sends the old note body
+                                                            noteObjecttoBeUpdated={getThisUpdatedNote(data)} // <--- This is not passing through the new modified note, it sends the old note body
                                                         />
 
                                                     </Textarea>


### PR DESCRIPTION
…ject rather than the specific note object properties. Then passed that whole object into the toast. Don't know why it works but it does.